### PR TITLE
`update readme` job calls the metrics it wants built

### DIFF
--- a/.github/workflows/update-readme-with-metrics.yml
+++ b/.github/workflows/update-readme-with-metrics.yml
@@ -6,8 +6,18 @@ on:
     - cron: '3 8 * * *'
 
 jobs:
+  collect-metrics:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: ./.github/workflows/website-performance.yml
+        with:
+          branch: workflows
+
+
   build:
     runs-on: ubuntu-20.04
+    needs: [collect-metrics]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/website-performance.yml
+++ b/.github/workflows/website-performance.yml
@@ -2,8 +2,6 @@ name: Collect Lighthouse metrics
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '25 7 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
Means that we can just do one workflow, and not rely on the other crons
having finished successfully first. Removes a potential race condition,
where the metrics jobs (website-performance) start late or overrun.

Ticket: https://trello.com/c/3WxSukEO/10-use-workflows-instead-of-i-hope-this-has-finished-by-now-crons